### PR TITLE
added styling to make exclamation point red in alert banner

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Artstor Support Theme based on Zendesk Copenhagen",
   "author": "Zendesk, ITHAKA",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [{

--- a/style.css
+++ b/style.css
@@ -615,6 +615,7 @@ table td, table th {
   color: $link_color;
 }
 
+/* Alert banner for support site */
 #errormessage {
   align-items: center;
   background-color: #ffefc2;
@@ -622,6 +623,10 @@ table td, table th {
   margin-bottom: 15px;
   border: 1px solid rgba(51, 51, 51, 0.25);
   border-radius: 3px;
+}
+
+#errormessage .fa-exclamation {
+  color: #dc2a2a;
 }
 
 /*this hides Activities from menu when a user is logged in. See JS for code that shows My Activities to internal users and users within ITHAKA org */

--- a/styles/_header.scss
+++ b/styles/_header.scss
@@ -93,14 +93,21 @@ $header-height: 71px;
   }
 }
 
+/* Alert banner for support site */
 #errormessage {
 	align-items: center;
 	background-color: #ffefc2;
 	padding: 32px;
 	margin-bottom: 15px;
 	border: 1px solid rgba(51,51,51,0.25);
-    border-radius: 3px;
+  border-radius: 3px;
+
+  .fa-exclamation {
+    color: #dc2a2a;
+    }
 }
+
+
 
 /*this hides Activities from menu when a user is logged in. See JS for code that shows My Activities to internal users and users within ITHAKA org */
    .my-activities, #user-menu .my-activities {


### PR DESCRIPTION
I forgot to add the styling to make the exclamation point red in the alert banner on the site. I believe the style I added under #errormessage should do it:

  .fa-exclamation {
  color: #dc2a2a;
}