### PR TITLE
added display:none to the status code

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Artstor Support Theme based on Zendesk Copenhagen",
   "author": "Zendesk, ITHAKA",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [{

--- a/templates/header.hbs
+++ b/templates/header.hbs
@@ -6,7 +6,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <script src="{{asset 'statuspage.js'}}"></script>
 <!--Below is what generates the banner HTML-->
 
-<div id = "errormessage"></div>
+<div id = "errormessage" style="display:None"></div>
 
 <script>
    var client = StatusPage("cmy3vpk5tq18");


### PR DESCRIPTION
Updated header.hbs statuspage code line to include display:None by default:

<div id = "errormessage" style="display:None"></div>

We think that Zendesk was loading code slowly, so was loading an empty banner first, then loading the script that looked for a banner and found none. 