### PR TITLE
09262019 manifest fix pt2

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -271,6 +271,12 @@
       "description": "contact_us_page_url",
       "label": "contact_us_page_url",
       "value": "https://www.artstor.org/contact-us/"
+    },{
+      "identifier": "login_link",
+      "type": "text",
+      "description": "login_link_url",
+      "label": "login_link_url",
+      "value": "https://library.artstor.org/#/login"
     }]
   }]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -237,11 +237,32 @@
       "value": "https://library.artstor.org"
     }],
     "variables": [{
-      "identifier": "marketing-page",
+      "identifier": "google-tag",
       "type": "text",
-      "description": "Marketing_page_link",
-      "label": "Marketing_page_label",
-      "value": "https://www.artstor.org/about/"
+      "description": "Google_tag_id_text",
+      "label": "Google_tag_id_text_label",
+      "value": "GTM-MCJFWS5"
+    }],
+    "variables": [{
+      "identifier": "statuspage-component",
+      "type": "text",
+      "description": "Statuspage_component_id",
+      "label": "Statuspage_component_id",
+      "value": "cmy3vpk5tq18"
+    }],
+    "variables": [{
+      "identifier": "product-name-text",
+      "type": "text",
+      "description": "Product_name_text",
+      "label": "Product_name_text_label",
+      "value": "Artstor Digital Library"
+    }],
+    "variables": [{
+      "identifier": "support-name-text",
+      "type": "text",
+      "description": "Support_name_text",
+      "label": "Support_name_text_label",
+      "value": "Artstor Support"
     }]
   }]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -29,7 +29,7 @@
       "type": "color",
       "description": "link_color_description",
       "label": "link_color_label",
-      "value": "$brand_color"
+      "value": "#C9510D"
     }, {
       "identifier": "background_color",
       "type": "color",

--- a/manifest.json
+++ b/manifest.json
@@ -235,41 +235,15 @@
       "description": "URL_for_product_homepage",
       "label": "product_homepage_label",
       "value": "https://library.artstor.org"
-    }],
+    }]
+  },{
+    "label": "tags_variable",
     "variables": [{
       "identifier": "google_tag",
       "type": "text",
       "description": "google_tag_id_text",
       "label": "google_tag_id_text_label",
       "value": "GTM-MCJFWS5"
-    }],
-    "variables": [{
-      "identifier": "marketing_page",
-      "type": "text",
-      "description": "marketing_page_link",
-      "label": "marketing_page_label",
-      "value": "https://www.artstor.org/about/"
-    }],
-    "variables": [{
-      "identifier": "statuspage_component",
-      "type": "text",
-      "description": "statuspage_component_id",
-      "label": "statuspage_component_id",
-      "value": "cmy3vpk5tq18"
-    }],
-    "variables": [{
-      "identifier": "product_name_text",
-      "type": "text",
-      "description": "product_name_text",
-      "label": "product_name_text_label",
-      "value": "Artstor Digital Library"
-    }],
-    "variables": [{
-      "identifier": "support_name_text",
-      "type": "text",
-      "description": "support_name_text",
-      "label": "support_name_text_label",
-      "value": "Artstor Support"
     }]
   }]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -241,6 +241,30 @@
       "description": "google_tag_id_text",
       "label": "google_tag_id_text_label",
       "value": "GTM-MCJFWS5"
+    },{
+      "identifier": "marketing_page",
+      "type": "text",
+      "description": "marketing_page_link",
+      "label": "marketing_page_label",
+      "value": "https://www.artstor.org/about/"
+    },{
+      "identifier": "statuspage_component",
+      "type": "text",
+      "description": "statuspage_component_id",
+      "label": "statuspage_component_id",
+      "value": "cmy3vpk5tq18"
+    },{
+      "identifier": "product_name_text",
+      "type": "text",
+      "description": "product_name_text",
+      "label": "product_name_text_label",
+      "value": "Artstor Digital Library"
+    },{
+      "identifier": "support_name_text",
+      "type": "text",
+      "description": "support_name_text",
+      "label": "support_name_text_label",
+      "value": "Artstor Support"
     }]
   }]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -265,6 +265,12 @@
       "description": "support_name_text",
       "label": "support_name_text_label",
       "value": "Artstor Support"
+    },{
+      "identifier": "contact_us_page",
+      "type": "text",
+      "description": "contact_us_page_url",
+      "label": "contact_us_page_url",
+      "value": "https://www.artstor.org/contact-us/"
     }]
   }]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -237,7 +237,7 @@
       "value": "https://library.artstor.org"
     }],
     "variables": [{
-      "identifier": "google-tag",
+      "identifier": "google_tag",
       "type": "text",
       "description": "Google_tag_id_text",
       "label": "Google_tag_id_text_label",

--- a/manifest.json
+++ b/manifest.json
@@ -235,6 +235,41 @@
       "description": "URL_for_product_homepage",
       "label": "product_homepage_label",
       "value": "https://library.artstor.org"
+    }],
+    "variables": [{
+      "identifier": "marketing-page",
+      "type": "text",
+      "description": "Marketing_page_link",
+      "label": "Marketing_page_label",
+      "value": "https://www.artstor.org/about/"
+    }],
+    "variables": [{
+      "identifier": "google-tag",
+      "type": "text",
+      "description": "Google_tag_id_text",
+      "label": "Google_tag_id_text_label",
+      "value": "GTM-MCJFWS5"
+    }],
+    "variables": [{
+      "identifier": "statuspage-component",
+      "type": "text",
+      "description": "Statuspage_component_id",
+      "label": "Statuspage_component_id",
+      "value": "cmy3vpk5tq18"
+    }],
+    "variables": [{
+      "identifier": "product-name-text",
+      "type": "text",
+      "description": "Product_name_text",
+      "label": "Product_name_text_label",
+      "value": "Artstor Digital Library"
+    }],
+    "variables": [{
+      "identifier": "support-name-text",
+      "type": "text",
+      "description": "Support_name_text",
+      "label": "Support_name_text_label",
+      "value": "Artstor Support"
     }]
   }]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -235,6 +235,6 @@
       "description": "URL_for_product_homepage",
       "label": "product_homepage_label",
       "value": "https://library.artstor.org"
-    }],
+    }]
   }]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -235,6 +235,41 @@
       "description": "URL_for_product_homepage",
       "label": "product_homepage_label",
       "value": "https://library.artstor.org"
+    }],
+    "variables": [{
+      "identifier": "google_tag",
+      "type": "text",
+      "description": "google_tag_id_text",
+      "label": "google_tag_id_text_label",
+      "value": "GTM-MCJFWS5"
+    }],
+    "variables": [{
+      "identifier": "marketing_page",
+      "type": "text",
+      "description": "marketing_page_link",
+      "label": "marketing_page_label",
+      "value": "https://www.artstor.org/about/"
+    }],
+    "variables": [{
+      "identifier": "statuspage_component",
+      "type": "text",
+      "description": "statuspage_component_id",
+      "label": "statuspage_component_id",
+      "value": "cmy3vpk5tq18"
+    }],
+    "variables": [{
+      "identifier": "product_name_text",
+      "type": "text",
+      "description": "product_name_text",
+      "label": "product_name_text_label",
+      "value": "Artstor Digital Library"
+    }],
+    "variables": [{
+      "identifier": "support_name_text",
+      "type": "text",
+      "description": "support_name_text",
+      "label": "support_name_text_label",
+      "value": "Artstor Support"
     }]
   }]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Artstor Support Theme based on Zendesk Copenhagen",
   "author": "Zendesk, ITHAKA",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [{
@@ -253,8 +253,8 @@
     "variables": [{
       "identifier": "statuspage-component",
       "type": "text",
-      "description": "Statuspage_component_id_text",
-      "label": "Statuspage_component_id_text_label",
+      "description": "Statuspage_component_id",
+      "label": "Statuspage_component_id",
       "value": "cmy3vpk5tq18"
     }],
     "variables": [{

--- a/manifest.json
+++ b/manifest.json
@@ -242,27 +242,6 @@
       "description": "Google_tag_id_text",
       "label": "Google_tag_id_text_label",
       "value": "GTM-MCJFWS5"
-    }],
-    "variables": [{
-      "identifier": "statuspage-component",
-      "type": "text",
-      "description": "Statuspage_component_id",
-      "label": "Statuspage_component_id",
-      "value": "cmy3vpk5tq18"
-    }],
-    "variables": [{
-      "identifier": "product-name-text",
-      "type": "text",
-      "description": "Product_name_text",
-      "label": "Product_name_text_label",
-      "value": "Artstor Digital Library"
-    }],
-    "variables": [{
-      "identifier": "support-name-text",
-      "type": "text",
-      "description": "Support_name_text",
-      "label": "Support_name_text_label",
-      "value": "Artstor Support"
     }]
   }]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -242,34 +242,6 @@
       "description": "Marketing_page_link",
       "label": "Marketing_page_label",
       "value": "https://www.artstor.org/about/"
-    }],
-    "variables": [{
-      "identifier": "google-tag",
-      "type": "text",
-      "description": "Google_tag_id_text",
-      "label": "Google_tag_id_text_label",
-      "value": "GTM-MCJFWS5"
-    }],
-    "variables": [{
-      "identifier": "statuspage-component",
-      "type": "text",
-      "description": "Statuspage_component_id",
-      "label": "Statuspage_component_id",
-      "value": "cmy3vpk5tq18"
-    }],
-    "variables": [{
-      "identifier": "product-name-text",
-      "type": "text",
-      "description": "Product_name_text",
-      "label": "Product_name_text_label",
-      "value": "Artstor Digital Library"
-    }],
-    "variables": [{
-      "identifier": "support-name-text",
-      "type": "text",
-      "description": "Support_name_text",
-      "label": "Support_name_text_label",
-      "value": "Artstor Support"
     }]
   }]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -235,13 +235,6 @@
       "description": "URL_for_product_homepage",
       "label": "product_homepage_label",
       "value": "https://library.artstor.org"
-    }],
-    "variables": [{
-      "identifier": "google_tag",
-      "type": "text",
-      "description": "Google_tag_id_text",
-      "label": "Google_tag_id_text_label",
-      "value": "GTM-MCJFWS5"
     }]
   }]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -235,10 +235,7 @@
       "description": "URL_for_product_homepage",
       "label": "product_homepage_label",
       "value": "https://library.artstor.org"
-    }]
-  },{
-    "label": "tags_variable",
-    "variables": [{
+    },{
       "identifier": "google_tag",
       "type": "text",
       "description": "google_tag_id_text",

--- a/manifest.json
+++ b/manifest.json
@@ -236,40 +236,5 @@
       "label": "product_homepage_label",
       "value": "https://library.artstor.org"
     }],
-    "variables": [{
-      "identifier": "marketing-page",
-      "type": "text",
-      "description": "Marketing_page_link",
-      "label": "Marketing_page_label",
-      "value": "https://www.artstor.org/about/"
-    }],
-    "variables": [{
-      "identifier": "google-tag",
-      "type": "text",
-      "description": "Google_tag_id_text",
-      "label": "Google_tag_id_text_label",
-      "value": "GTM-MCJFWS5"
-    }],
-    "variables": [{
-      "identifier": "statuspage-component",
-      "type": "text",
-      "description": "Statuspage_component_id",
-      "label": "Statuspage_component_id",
-      "value": "cmy3vpk5tq18"
-    }],
-    "variables": [{
-      "identifier": "product-name-text",
-      "type": "text",
-      "description": "Product_name_text",
-      "label": "Product_name_text_label",
-      "value": "Artstor Digital Library"
-    }],
-    "variables": [{
-      "identifier": "support-name-text",
-      "type": "text",
-      "description": "Support_name_text",
-      "label": "Support_name_text_label",
-      "value": "Artstor Support"
-    }]
   }]
 }


### PR DESCRIPTION
My dumb amount of commits amounted to the revelation that I had written the site specific variables incorrectly in the manifest the first time around. Things I have learned:
- you cannot use variables like $gray in the manifest
- identifiers cannot be more than 30 characters
- identifier must be lower case
- it doesn't work to have multiple variables within a label, instead you have multiple identifiers



