### PR TITLE
Updated accessibility link in Forum footer

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Forum Support theme - a fork of Zendesk Copenhagen",
   "author": "Zendesk, ITHAKA",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [{

--- a/templates/footer.hbs
+++ b/templates/footer.hbs
@@ -78,7 +78,7 @@
             <a href="https://www.ithaka.org/cookies/">Cookies</a>
           </li>
           <li>
-            <a href="https://www.artstor.org/accessibility/">Accessibility</a>
+            <a href="https://support.forum.jstor.org/hc/en-us/articles/360034045213-Accessibility">Accessibility</a>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
Updated accessibility link in the Forum footer to an article with new VPAT info:

https://support.forum.jstor.org/hc/en-us/articles/360034045213-Accessibility